### PR TITLE
Refactor composables to use injected anime

### DIFF
--- a/src/runtime/composables/useDraggable.ts
+++ b/src/runtime/composables/useDraggable.ts
@@ -1,1 +1,5 @@
-export { createDraggable as useDraggable } from 'animejs'
+import { useNuxtApp } from '#imports'
+
+export const useDraggable = (...args: any[]) => {
+  return useNuxtApp().$anime.createDraggable(...args)
+}

--- a/src/runtime/composables/useScope.ts
+++ b/src/runtime/composables/useScope.ts
@@ -1,2 +1,6 @@
 // src/runtime/composables/useScope.ts
-export { createScope as useScope } from 'animejs'
+import { useNuxtApp } from '#imports'
+
+export const useScope = (...args: any[]) => {
+  return useNuxtApp().$anime.createScope(...args)
+}

--- a/src/runtime/composables/useScroll.ts
+++ b/src/runtime/composables/useScroll.ts
@@ -1,1 +1,5 @@
-export { onScroll as useScroll } from 'animejs'
+import { useNuxtApp } from '#imports'
+
+export const useScroll = (...args: any[]) => {
+  return useNuxtApp().$anime.onScroll(...args)
+}

--- a/src/runtime/composables/useStagger.ts
+++ b/src/runtime/composables/useStagger.ts
@@ -1,1 +1,5 @@
-export { stagger as useStagger } from 'animejs'
+import { useNuxtApp } from '#imports'
+
+export const useStagger = (...args: any[]) => {
+  return useNuxtApp().$anime.stagger(...args)
+}

--- a/src/runtime/composables/useSvg.ts
+++ b/src/runtime/composables/useSvg.ts
@@ -1,3 +1,7 @@
-import { svg } from 'animejs'
+import { useNuxtApp } from '#imports'
 
-export const { createMotionPath, createDrawable, morphTo } = svg
+const svg = () => useNuxtApp().$anime.svg
+
+export const createMotionPath = (...args: any[]) => svg().createMotionPath(...args)
+export const createDrawable = (...args: any[]) => svg().createDrawable(...args)
+export const morphTo = (...args: any[]) => svg().morphTo(...args)

--- a/src/runtime/composables/useText.ts
+++ b/src/runtime/composables/useText.ts
@@ -1,3 +1,5 @@
-import { text } from 'animejs'
+import { useNuxtApp } from '#imports'
 
-export const useTextSplit = text.split
+export const useTextSplit = (...args: any[]) => {
+  return useNuxtApp().$anime.text.split(...args)
+}

--- a/src/runtime/composables/useTimeline.ts
+++ b/src/runtime/composables/useTimeline.ts
@@ -1,3 +1,5 @@
-import { createTimeline, type TimelineParams } from 'animejs'
+import { useNuxtApp } from '#imports'
 
-export const useTimeline = (params?: TimelineParams) => createTimeline(params)
+export const useTimeline = (params?: any) => {
+  return useNuxtApp().$anime.createTimeline(params)
+}

--- a/src/runtime/composables/useUtils.ts
+++ b/src/runtime/composables/useUtils.ts
@@ -1,3 +1,3 @@
-import { utils } from 'animejs'
+import { useNuxtApp } from '#imports'
 
-export { utils as useUtils }
+export const useUtils = () => useNuxtApp().$anime.utils

--- a/src/runtime/plugin.client.ts
+++ b/src/runtime/plugin.client.ts
@@ -4,8 +4,7 @@ import { defineNuxtPlugin, useRuntimeConfig } from 'nuxt/app'
 export default defineNuxtPlugin(async (nuxtApp) => {
   const loadAnime = async () => {
     try {
-      const { animate, createTimeline, stagger, utils, svg } = await import('animejs')
-      return { animate, createTimeline, stagger, utils, svg }
+      return await import('animejs')
     }
     catch (error) {
       console.warn('Failed to load anime.js:', error)

--- a/src/runtime/plugin.server.ts
+++ b/src/runtime/plugin.server.ts
@@ -30,6 +30,12 @@ export default defineNuxtPlugin((nuxtApp) => {
       revert: () => {},
       then: (callback?: Function) => Promise.resolve().then(() => callback && callback()),
     }),
+    createDraggable: () => ({
+      on: () => {},
+      destroy: () => {},
+    }),
+    onScroll: () => {},
+    createScope: () => ({}),
     stagger: () => [],
     utils: {
       get: () => null,
@@ -40,6 +46,9 @@ export default defineNuxtPlugin((nuxtApp) => {
       createMotionPath: () => ({}),
       morphTo: () => ({}),
       createDrawable: () => ({}),
+    },
+    text: {
+      split: () => [],
     },
   }
 

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -4,6 +4,9 @@
 export interface AnimeJS {
   animate: (targets: any, params?: AnimationParams) => Animation
   createTimeline: () => Timeline
+  createDraggable: (...args: any[]) => any
+  onScroll: (...args: any[]) => any
+  createScope: (...args: any[]) => any
   stagger: (value: any, options?: StaggerOptions) => any[]
   utils: {
     get: (targets: any, prop: string) => any
@@ -14,6 +17,9 @@ export interface AnimeJS {
     createMotionPath: (path: string) => any
     morphTo: (path: string) => any
     createDrawable: (path: string) => any
+  }
+  text: {
+    split: (...args: any[]) => any
   }
 }
 


### PR DESCRIPTION
## Summary
- inject `animejs` instance in all composables instead of static imports
- load full module in plugin to provide all helpers
- extend server plugin fallback and typings

## Testing
- `npm run lint` *(fails: Cannot find package '@nuxt/eslint-config')*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688329f5aed0832f9f154914c840ab3f