### PR TITLE
Fix server timeline fallback

### DIFF
--- a/src/runtime/plugin.server.ts
+++ b/src/runtime/plugin.server.ts
@@ -20,16 +20,19 @@ export default defineNuxtPlugin((nuxtApp) => {
 
   const serverFallback = {
     animate: () => noOpAnimation(),
-    createTimeline: () => ({
-      add: () => serverFallback,
-      play: () => {},
-      pause: () => {},
-      restart: () => {},
-      seek: () => {},
-      cancel: () => {},
-      revert: () => {},
-      then: (callback?: Function) => Promise.resolve().then(() => callback && callback()),
-    }),
+    createTimeline: () => {
+      const timeline = {
+        add: () => timeline,
+        play: () => {},
+        pause: () => {},
+        restart: () => {},
+        seek: () => {},
+        cancel: () => {},
+        revert: () => {},
+        then: (callback?: Function) => Promise.resolve().then(() => callback && callback()),
+      }
+      return timeline
+    },
     stagger: () => [],
     utils: {
       get: () => null,


### PR DESCRIPTION
## Summary
- return the same timeline instance when `createTimeline().add()` is called on the server

## Testing
- `npm run lint` *(fails: cannot find package '@nuxt/eslint-config')*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883271fea94832fa273e79e3ab48c9f