### PR TITLE
Fix timeline chaining on server

### DIFF
--- a/src/runtime/plugin.server.ts
+++ b/src/runtime/plugin.server.ts
@@ -20,16 +20,19 @@ export default defineNuxtPlugin((nuxtApp) => {
 
   const serverFallback = {
     animate: () => noOpAnimation(),
-    createTimeline: () => ({
-      add: () => serverFallback,
-      play: () => {},
-      pause: () => {},
-      restart: () => {},
-      seek: () => {},
-      cancel: () => {},
-      revert: () => {},
-      then: (callback?: Function) => Promise.resolve().then(() => callback && callback()),
-    }),
+    createTimeline: () => {
+      const timeline = {
+        add: () => timeline,
+        play: () => {},
+        pause: () => {},
+        restart: () => {},
+        seek: () => {},
+        cancel: () => {},
+        revert: () => {},
+        then: (callback?: Function) => Promise.resolve().then(() => callback && callback()),
+      }
+      return timeline
+    },
     stagger: () => [],
     utils: {
       get: () => null,


### PR DESCRIPTION
## Summary
- make `createTimeline()` use a timeline object whose `add()` returns itself

## Testing
- `npm run lint` *(fails: Cannot find package '@nuxt/eslint-config')*
- `npm run test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883272187f0832fa98e136537755e13