### PR TITLE
Fix missing animejs composables

### DIFF
--- a/src/runtime/composables/useScope.ts
+++ b/src/runtime/composables/useScope.ts
@@ -1,2 +1,7 @@
 // src/runtime/composables/useScope.ts
-export { createScope as useScope } from 'animejs'
+import { useNuxtApp } from 'nuxt/app'
+
+export const useScope = () => {
+  const { $anime } = useNuxtApp()
+  return $anime.createScope()
+}

--- a/src/runtime/composables/useScroll.ts
+++ b/src/runtime/composables/useScroll.ts
@@ -1,1 +1,6 @@
-export { onScroll as useScroll } from 'animejs'
+import { useNuxtApp } from 'nuxt/app'
+
+export const useScroll = (...args: any[]) => {
+  const { $anime } = useNuxtApp()
+  return $anime.onScroll(...args)
+}

--- a/src/runtime/composables/useSvg.ts
+++ b/src/runtime/composables/useSvg.ts
@@ -1,4 +1,12 @@
-import { svg } from 'animejs'
+import { useNuxtApp } from 'nuxt/app'
 
-export const useSvg = svg
-export const { createMotionPath, createDrawable, morphTo } = svg
+export const useSvg = () => useNuxtApp().$anime.svg
+
+export const createMotionPath = (...args: any[]) =>
+  useNuxtApp().$anime.svg.createMotionPath(...args)
+
+export const createDrawable = (...args: any[]) =>
+  useNuxtApp().$anime.svg.createDrawable(...args)
+
+export const morphTo = (...args: any[]) =>
+  useNuxtApp().$anime.svg.morphTo(...args)

--- a/src/runtime/composables/useText.ts
+++ b/src/runtime/composables/useText.ts
@@ -1,3 +1,4 @@
-import { text } from 'animejs'
+import { useNuxtApp } from 'nuxt/app'
 
-export const useTextSplit = text.split
+export const useTextSplit = (...args: any[]) =>
+  useNuxtApp().$anime.text.split(...args)

--- a/src/runtime/plugin.client.ts
+++ b/src/runtime/plugin.client.ts
@@ -4,8 +4,8 @@ import { defineNuxtPlugin, useRuntimeConfig } from 'nuxt/app'
 export default defineNuxtPlugin(async (nuxtApp) => {
   const loadAnime = async () => {
     try {
-      const { animate, createTimeline, stagger, utils, svg } = await import('animejs')
-      return { animate, createTimeline, stagger, utils, svg }
+      const { animate, createTimeline, stagger, utils, svg, onScroll, createScope, text } = await import('animejs')
+      return { animate, createTimeline, stagger, utils, svg, onScroll, createScope, text }
     }
     catch (error) {
       return null

--- a/src/runtime/plugin.server.ts
+++ b/src/runtime/plugin.server.ts
@@ -34,6 +34,13 @@ export default defineNuxtPlugin((nuxtApp) => {
       return timeline
     },
     stagger: () => [],
+    onScroll: () => noOpAnimation(),
+    createScope: () => ({
+      animate: () => noOpAnimation(),
+    }),
+    text: {
+      split: () => [],
+    },
     utils: {
       get: () => null,
       set: () => {},

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -5,6 +5,8 @@ export interface AnimeJS {
   animate: (targets: any, params?: AnimationParams) => Animation
   createTimeline: () => Timeline
   stagger: (value: any, options?: StaggerOptions) => any[]
+  onScroll: (target: any, params?: AnimationParams) => Animation
+  createScope: () => { animate: AnimeJS['animate'] }
   utils: {
     get: (targets: any, prop: string) => any
     set: (targets: any, prop: string, value: any) => void
@@ -14,6 +16,9 @@ export interface AnimeJS {
     createMotionPath: (path: string) => any
     morphTo: (path: string) => any
     createDrawable: (path: string) => any
+  }
+  text: {
+    split: (el: any) => any[]
   }
 }
 


### PR DESCRIPTION
## Summary
- wire up new anime.js composables to `$anime` plugin
- extend plugin to expose `onScroll`, `createScope` and `text`
- provide SSR fallbacks for these new APIs
- update types

## Testing
- `npm run lint` *(fails: Cannot find package '@nuxt/eslint-config')*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68833b988ed4832f93c246ba23eb6c27