### PR TITLE
Improve playground examples and add useTimer composable

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ anime.js in your components without extra setup.
 
 * Zero configuration – just install and start animating
 * Works with both client-side and server-side rendering
-* Useful composables like `useAnimate` and `useTimeline`
+* Useful composables like `useAnimate`, `useTimeline`, and `useTimer`
 
 ## Quick Setup
 

--- a/playground/components/UseAnimate.vue
+++ b/playground/components/UseAnimate.vue
@@ -6,6 +6,12 @@
     >
       Animasi Sederhana
     </div>
+    <div
+      ref="box2"
+      class="box"
+    >
+      Rotate
+    </div>
     <button @click="play">
       Play
     </button>
@@ -27,9 +33,26 @@ const controls = useAnimate(box, {
   autoplay: false,
 })
 
-const play = () => controls.play()
-const pause = () => controls.pause()
-const restart = () => controls.restart()
+const box2 = ref<HTMLElement | null>(null)
+const controls2 = useAnimate(box2, {
+  rotate: [0, 360],
+  duration: 1500,
+  loop: true,
+  autoplay: false,
+})
+
+const play = () => {
+  controls.play()
+  controls2.play()
+}
+const pause = () => {
+  controls.pause()
+  controls2.pause()
+}
+const restart = () => {
+  controls.restart()
+  controls2.restart()
+}
 </script>
 
 <style scoped>

--- a/playground/components/UseDraggable.vue
+++ b/playground/components/UseDraggable.vue
@@ -1,15 +1,19 @@
 <template>
   <div>
     <div ref="box" class="box">Drag me</div>
+    <div ref="box2" class="box">Drag me 2</div>
   </div>
 </template>
 
 <script setup lang="ts">
 const box = ref<HTMLElement | null>(null)
+const box2 = ref<HTMLElement | null>(null)
 
 onMounted(() => {
   if (box.value)
     useDraggable(box.value)
+  if (box2.value)
+    useDraggable(box2.value)
 })
 </script>
 

--- a/playground/components/UseScope.vue
+++ b/playground/components/UseScope.vue
@@ -1,18 +1,28 @@
 <template>
   <div>
     <div ref="box" class="box">Scoped</div>
+    <div ref="box2" class="box">Scoped 2</div>
     <button @click="run">Run Scope</button>
+    <button @click="run2">Run Scope 2</button>
   </div>
 </template>
 
 <script setup lang="ts">
 const box = ref<HTMLElement | null>(null)
 const scope = useScope()
+const box2 = ref<HTMLElement | null>(null)
+const scope2 = useScope()
 
 const run = () => {
   if (!box.value)
     return
   scope.animate(box.value, { x: [0, 80], background: '#9b59b6', duration: 600 })
+}
+
+const run2 = () => {
+  if (!box2.value)
+    return
+  scope2.animate(box2.value, { y: [0, 80], background: '#2980b9', duration: 600 })
 }
 </script>
 

--- a/playground/components/UseScroll.vue
+++ b/playground/components/UseScroll.vue
@@ -1,15 +1,19 @@
 <template>
   <div style="height: 150vh;">
     <div ref="box" class="box">Scroll</div>
+    <div ref="box2" class="box">Scroll 2</div>
   </div>
 </template>
 
 <script setup lang="ts">
 const box = ref<HTMLElement | null>(null)
+const box2 = ref<HTMLElement | null>(null)
 
 onMounted(() => {
   if (box.value)
     useScroll(box.value, { y: [0, 200] })
+  if (box2.value)
+    useScroll(box2.value, { x: [0, 200] })
 })
 </script>
 

--- a/playground/components/UseStagger.vue
+++ b/playground/components/UseStagger.vue
@@ -3,13 +3,18 @@
     <div ref="wrap" class="wrap">
       <div v-for="n in 5" :key="n" class="box">{{ n }}</div>
     </div>
+    <div ref="wrap2" class="wrap">
+      <div v-for="n in 3" :key="`b-${n}`" class="box">B{{ n }}</div>
+    </div>
     <button @click="run">Stagger</button>
+    <button @click="run2">Stagger 2</button>
   </div>
 </template>
 
 <script setup lang="ts">
 const wrap = ref<HTMLElement | null>(null)
 const { $anime } = useNuxtApp()
+const wrap2 = ref<HTMLElement | null>(null)
 
 const run = () => {
   if (!wrap.value)
@@ -17,6 +22,13 @@ const run = () => {
   const boxes = wrap.value.querySelectorAll('.box')
   const offset = useStagger(20)
   $anime.animate(boxes, { x: offset, delay: useStagger(100) })
+}
+
+const run2 = () => {
+  if (!wrap2.value)
+    return
+  const boxes = wrap2.value.querySelectorAll('.box')
+  $anime.animate(boxes, { scale: useStagger([1, 1.5]), delay: useStagger(80) })
 }
 </script>
 

--- a/playground/components/UseSvg.vue
+++ b/playground/components/UseSvg.vue
@@ -4,13 +4,19 @@
       <path id="p" d="M10 80 Q 95 10 180 80" fill="transparent" stroke="#555" />
       <circle ref="dot" r="5" fill="#e74c3c" />
     </svg>
+    <svg width="200" height="100" viewBox="0 0 200 100">
+      <path id="p2" d="M10 20 Q 95 90 180 20" fill="transparent" stroke="#555" />
+      <circle ref="dot2" r="5" fill="#2ecc71" />
+    </svg>
     <button @click="animatePath">Animate Path</button>
+    <button @click="animatePath2">Animate Path 2</button>
   </div>
 </template>
 
 <script setup lang="ts">
 const dot = ref<SVGCircleElement | null>(null)
-const { createMotionPath } = useSvg
+const dot2 = ref<SVGCircleElement | null>(null)
+const { createMotionPath } = useSvg()
 const { $anime } = useNuxtApp()
 
 const animatePath = () => {
@@ -18,6 +24,13 @@ const animatePath = () => {
     return
   const path = createMotionPath('#p')
   $anime.animate(dot.value, { translateX: path('x'), translateY: path('y'), duration: 1000 })
+}
+
+const animatePath2 = () => {
+  if (!dot2.value)
+    return
+  const path = createMotionPath('#p2')
+  $anime.animate(dot2.value, { translateX: path('x'), translateY: path('y'), duration: 1000 })
 }
 </script>
 

--- a/playground/components/UseText.vue
+++ b/playground/components/UseText.vue
@@ -1,19 +1,29 @@
 <template>
   <div>
     <p ref="text">Anime.js Text Split Example</p>
+    <p ref="text2">Another Split Example</p>
     <button @click="animate">Animate</button>
+    <button @click="animate2">Animate 2</button>
   </div>
 </template>
 
 <script setup lang="ts">
 const text = ref<HTMLElement | null>(null)
 const { $anime } = useNuxtApp()
+const text2 = ref<HTMLElement | null>(null)
 
 const animate = () => {
   if (!text.value)
     return
   const chars = useTextSplit(text.value)
   $anime.animate(chars, { y: [20, 0], opacity: [0, 1], delay: useStagger(30) })
+}
+
+const animate2 = () => {
+  if (!text2.value)
+    return
+  const chars = useTextSplit(text2.value)
+  $anime.animate(chars, { y: [-20, 0], opacity: [0, 1], delay: useStagger(40) })
 }
 </script>
 

--- a/playground/components/UseTimeline.vue
+++ b/playground/components/UseTimeline.vue
@@ -1,13 +1,17 @@
 <template>
   <div>
     <div ref="box" class="box">Timeline</div>
+    <div ref="box2" class="box">Timeline 2</div>
     <button @click="start">Start</button>
+    <button @click="start2">Start 2</button>
   </div>
 </template>
 
 <script setup lang="ts">
 const box = ref<HTMLElement | null>(null)
 const timeline = useTimeline({ autoplay: false })
+const box2 = ref<HTMLElement | null>(null)
+const timeline2 = useTimeline({ autoplay: false })
 
 const start = () => {
   if (!box.value)
@@ -16,6 +20,15 @@ const start = () => {
     .add(box.value, { x: [0, 120], duration: 500 })
     .add(box.value, { y: [0, 120], duration: 500 })
   timeline.play()
+}
+
+const start2 = () => {
+  if (!box2.value)
+    return
+  timeline2
+    .add(box2.value, { scale: [1, 1.5], duration: 400 })
+    .add(box2.value, { rotate: [0, 180], duration: 400 })
+  timeline2.play()
 }
 </script>
 

--- a/playground/components/UseUtils.vue
+++ b/playground/components/UseUtils.vue
@@ -1,18 +1,28 @@
 <template>
   <div>
     <div ref="box" class="box">Utils</div>
+    <div ref="box2" class="box">Utils 2</div>
     <button @click="randomize">Random Color</button>
+    <button @click="randomize2">Random Color 2</button>
   </div>
 </template>
 
 <script setup lang="ts">
 const box = ref<HTMLElement | null>(null)
+const box2 = ref<HTMLElement | null>(null)
 
 const randomize = () => {
   if (!box.value)
     return
   const color = useUtils.random(['#e74c3c', '#3498db', '#2ecc71'])
   box.value.style.background = color
+}
+
+const randomize2 = () => {
+  if (!box2.value)
+    return
+  const color = useUtils.random(['#9b59b6', '#1abc9c', '#f1c40f'])
+  box2.value.style.background = color
 }
 </script>
 

--- a/src/runtime/composables/useTimer.ts
+++ b/src/runtime/composables/useTimer.ts
@@ -1,0 +1,5 @@
+import { useNuxtApp } from 'nuxt/app'
+
+export const useTimer = (...args: any[]) => {
+  return useNuxtApp().$anime.timer(...args)
+}

--- a/src/runtime/plugin.client.ts
+++ b/src/runtime/plugin.client.ts
@@ -4,8 +4,8 @@ import { defineNuxtPlugin, useRuntimeConfig } from 'nuxt/app'
 export default defineNuxtPlugin(async (nuxtApp) => {
   const loadAnime = async () => {
     try {
-      const { animate, createTimeline, stagger, utils, svg, onScroll, createScope, text } = await import('animejs')
-      return { animate, createTimeline, stagger, utils, svg, onScroll, createScope, text }
+      const { animate, createTimeline, stagger, utils, svg, onScroll, createScope, text, timer } = await import('animejs')
+      return { animate, createTimeline, stagger, utils, svg, onScroll, createScope, text, timer }
     }
     catch (error) {
       return null

--- a/src/runtime/plugin.server.ts
+++ b/src/runtime/plugin.server.ts
@@ -38,6 +38,7 @@ export default defineNuxtPlugin((nuxtApp) => {
     createScope: () => ({
       animate: () => noOpAnimation(),
     }),
+    timer: () => noOpAnimation(),
     text: {
       split: () => [],
     },

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -7,6 +7,7 @@ export interface AnimeJS {
   stagger: (value: any, options?: StaggerOptions) => any[]
   onScroll: (target: any, params?: AnimationParams) => Animation
   createScope: () => { animate: AnimeJS['animate'] }
+  timer: (...args: any[]) => Animation
   utils: {
     get: (targets: any, prop: string) => any
     set: (targets: any, prop: string, value: any) => void

--- a/str.md
+++ b/str.md
@@ -14,6 +14,7 @@ animejs-nuxt/
  │        ├─ useStagger.ts
  │        ├─ useSvg.ts
  │        ├─ useText.ts
+ │        ├─ useTimer.ts
  │        └─ useUtils.ts
  ├─ playground/               # app demo Nuxt
  ├─ package.json


### PR DESCRIPTION
## Summary
- fix `useSvg` example and expand every playground component with a second sample
- add missing `useTimer` composable with typings
- expose timer from plugins and update fallback
- document new composable in README and repo structure

## Testing
- `npm run lint` *(fails: Cannot find package '@nuxt/eslint-config')*
- `npm run test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68834092bf28832fb6c7670f7166c135