### PR TITLE
Add createDraggable support

### DIFF
--- a/src/runtime/plugin.client.ts
+++ b/src/runtime/plugin.client.ts
@@ -4,8 +4,8 @@ import { defineNuxtPlugin, useRuntimeConfig } from 'nuxt/app'
 export default defineNuxtPlugin(async (nuxtApp) => {
   const loadAnime = async () => {
     try {
-      const { animate, createTimeline, stagger, utils, svg, onScroll, createScope, text, timer } = await import('animejs')
-      return { animate, createTimeline, stagger, utils, svg, onScroll, createScope, text, timer }
+      const { animate, createTimeline, stagger, utils, svg, onScroll, createScope, text, timer, createDraggable } = await import('animejs')
+      return { animate, createTimeline, stagger, utils, svg, onScroll, createScope, text, timer, createDraggable }
     }
     catch (error) {
       return null

--- a/src/runtime/plugin.server.ts
+++ b/src/runtime/plugin.server.ts
@@ -39,6 +39,7 @@ export default defineNuxtPlugin((nuxtApp) => {
       animate: () => noOpAnimation(),
     }),
     timer: () => noOpAnimation(),
+    createDraggable: () => ({}),
     text: {
       split: () => [],
     },

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -8,6 +8,7 @@ export interface AnimeJS {
   onScroll: (target: any, params?: AnimationParams) => Animation
   createScope: () => { animate: AnimeJS['animate'] }
   timer: (...args: any[]) => Animation
+  createDraggable: (...args: any[]) => any
   utils: {
     get: (targets: any, prop: string) => any
     set: (targets: any, prop: string, value: any) => void


### PR DESCRIPTION
## Summary
- expose `createDraggable` in client plugin and server fallback
- add type for `createDraggable`

## Testing
- `npm run lint` *(fails: Cannot find package '@nuxt/eslint-config')*
- `npm run test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68834770a214832faa7a21e2627d9cda