### PR TITLE
Add timer demo component

### DIFF
--- a/playground/app.vue
+++ b/playground/app.vue
@@ -9,6 +9,7 @@
     <UseUtils />
     <UseDraggable />
     <UseScroll />
+    <UseTimer />
   </div>
 </template>
 
@@ -22,6 +23,7 @@ import UseText from '~/components/UseText.vue'
 import UseUtils from '~/components/UseUtils.vue'
 import UseDraggable from '~/components/UseDraggable.vue'
 import UseScroll from '~/components/UseScroll.vue'
+import UseTimer from '~/components/UseTimer.vue'
 </script>
 
 <style>

--- a/playground/components/UseTimer.vue
+++ b/playground/components/UseTimer.vue
@@ -1,0 +1,41 @@
+<template>
+  <div>
+    <div class="box">{{ display }}</div>
+    <button @click="play">Play</button>
+    <button @click="pause">Pause</button>
+    <button @click="restart">Restart</button>
+  </div>
+</template>
+
+<script setup lang="ts">
+const progress = ref(0)
+
+const timer = useTimer({
+  duration: 3000,
+  autoplay: false,
+  onUpdate(animation: any) {
+    if (animation && typeof animation.currentTime === 'number' && typeof animation.duration === 'number')
+      progress.value = (animation.currentTime / animation.duration) * 100
+  },
+})
+
+const play = () => timer.play()
+const pause = () => timer.pause()
+const restart = () => timer.restart()
+
+const display = computed(() => `${Math.round(progress.value)}%`)
+</script>
+
+<style scoped>
+.box {
+  width: 80px;
+  height: 80px;
+  background: #e74c3c;
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 1rem;
+  border-radius: 6px;
+}
+</style>


### PR DESCRIPTION
## Summary
- add `UseTimer.vue` to showcase basic `useTimer`
- display new timer demo in playground `app.vue`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@nuxt/eslint-config')*

------
https://chatgpt.com/codex/tasks/task_e_68834770cce8832f8c0fc5420b318a3f