### PR TITLE
Fix delay type

### DIFF
--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -4,7 +4,7 @@
 export interface AnimeJS {
   animate: (targets: any, params?: AnimationParams) => Animation
   createTimeline: () => Timeline
-  stagger: (value: any, options?: StaggerOptions) => any[]
+  stagger: (value: any, options?: StaggerOptions) => StaggerFunction
   onScroll: (target: any, params?: AnimationParams) => Animation
   createScope: () => { animate: AnimeJS['animate'] }
   createDraggable: (...args: any[]) => any
@@ -26,7 +26,7 @@ export interface AnimeJS {
 // ✅ anime.js v4 parameter types
 export interface AnimationParams {
   duration?: number
-  delay?: number
+  delay?: number | string | StaggerFunction
   ease?: string | Function
   loop?: number | boolean
   alternate?: boolean
@@ -60,6 +60,8 @@ export interface StaggerOptions {
   reversed?: boolean
   grid?: [number, number]
 }
+
+export type StaggerFunction = (el: any, index: number, total: number) => number
 
 // ✅ Nuxt plugin types
 declare module '#app' {


### PR DESCRIPTION
## Summary
- fix types for the `stagger` helper and `AnimationParams.delay`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688352896bc0832f84c1696f18232e60