### PR TITLE
Fix delay type

### DIFF
--- a/src/runtime/composables/useAnimate.ts
+++ b/src/runtime/composables/useAnimate.ts
@@ -3,13 +3,15 @@ import { ref, onMounted, onUnmounted, nextTick, watch } from 'vue'
 import type { Ref } from 'vue'
 import { useNuxtApp } from 'nuxt/app'
 
+import type { StaggerFunction } from '../types'
+
 export interface UseAnimateOptions {
   x?: number | string | number[] | string[]
   y?: number | string | number[] | string[]
   scale?: number | number[]
   rotate?: number | string | number[]
   duration?: number
-  delay?: number | ((el: any, i: number) => number)
+  delay?: number | string | StaggerFunction
   ease?: string
   loop?: boolean | number
   alternate?: boolean

--- a/src/runtime/plugin.server.ts
+++ b/src/runtime/plugin.server.ts
@@ -33,7 +33,7 @@ export default defineNuxtPlugin((nuxtApp) => {
       }
       return timeline
     },
-    stagger: () => [],
+    stagger: () => () => 0,
     onScroll: () => noOpAnimation(),
     createScope: () => ({
       animate: () => noOpAnimation(),

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -4,7 +4,7 @@
 export interface AnimeJS {
   animate: (targets: any, params?: AnimationParams) => Animation
   createTimeline: () => Timeline
-  stagger: (value: any, options?: StaggerOptions) => any[]
+  stagger: (value: any, options?: StaggerOptions) => StaggerFunction
   onScroll: (target: any, params?: AnimationParams) => Animation
   createScope: () => { animate: AnimeJS['animate'] }
   createDraggable: (...args: any[]) => any
@@ -26,7 +26,7 @@ export interface AnimeJS {
 // ✅ anime.js v4 parameter types
 export interface AnimationParams {
   duration?: number
-  delay?: number
+  delay?: number | string | StaggerFunction
   ease?: string | Function
   loop?: number | boolean
   alternate?: boolean
@@ -60,6 +60,9 @@ export interface StaggerOptions {
   reversed?: boolean
   grid?: [number, number]
 }
+
+// Re-export the anime.js type to avoid mismatched signatures
+export type StaggerFunction = (el: any, index: number, total: number) => number | string
 
 // ✅ Nuxt plugin types
 declare module '#app' {


### PR DESCRIPTION
## Summary
- fix types for the `stagger` helper and `AnimationParams.delay`
- align StaggerFunction signatures with anime.js and fix server fallback
- extend `useAnimate` delay option to accept `StaggerFunction`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688352896bc0832f84c1696f18232e60